### PR TITLE
Updated the File Change Reloading Strategy to work with config files in subdirectories

### DIFF
--- a/cfg4k-core/src/main/kotlin/com/jdiazcano/cfg4k/reloadstrategies/FileChangeReloadStrategy.kt
+++ b/cfg4k-core/src/main/kotlin/com/jdiazcano/cfg4k/reloadstrategies/FileChangeReloadStrategy.kt
@@ -46,6 +46,8 @@ class FileChangeReloadStrategy(val file: Path) : ReloadStrategy {
 
     override fun register(configProvider: ConfigProvider) {
         val fileWatcher = file.toAbsolutePath().parent.register(watcher, StandardWatchEventKinds.ENTRY_MODIFY)
+        val parent = file.toAbsolutePath().parent
+        val fileAbsolute = file.toAbsolutePath()
         watching = true
         thread = thread(start = true, isDaemon = true) {
             while (watching) {
@@ -53,7 +55,7 @@ class FileChangeReloadStrategy(val file: Path) : ReloadStrategy {
                     val key = watcher.take()
                     fileWatcher.pollEvents().forEach { event ->
                         val fileName = event.context() as Path
-                        if (fileName == file) {
+                        if (parent.resolve(fileName) == fileAbsolute) {
                             configProvider.reload()
                         }
                     }

--- a/cfg4k-core/src/test/kotlin/com/jdiazcano/cfg4k/FileChangeReloadStrategyTest.kt
+++ b/cfg4k-core/src/test/kotlin/com/jdiazcano/cfg4k/FileChangeReloadStrategyTest.kt
@@ -47,11 +47,7 @@ class FileChangeReloadStrategyTest : Spek({
         file.toFile().deleteOnExit()
         file.toFile().writeText("foo=bar")
 
-        val unrelatedFile = Paths.get("subdir/subdir", "reloadedfile.properties")
-        unrelatedFile.parent.toFile().mkdir()
-        unrelatedFile.parent.toFile().deleteOnExit()
-        unrelatedFile.toFile().deleteOnExit()
-        unrelatedFile.toFile().writeText("foo=bar")
+
         val provider = DefaultConfigProvider(
                 PropertyConfigLoader(FileConfigSource(file)),
                 FileChangeReloadStrategy(file),

--- a/cfg4k-core/src/test/kotlin/com/jdiazcano/cfg4k/FileChangeReloadStrategyTest.kt
+++ b/cfg4k-core/src/test/kotlin/com/jdiazcano/cfg4k/FileChangeReloadStrategyTest.kt
@@ -15,6 +15,7 @@ import java.nio.file.Paths
 class FileChangeReloadStrategyTest : Spek({
     describe("a provider with a filechange reloader") {
         val file = Paths.get("test.properties")
+        file.toFile().deleteOnExit()
         file.toFile().writeText("foo=bar")
         val provider = DefaultConfigProvider(
                 PropertyConfigLoader(FileConfigSource(file)),
@@ -34,8 +35,42 @@ class FileChangeReloadStrategyTest : Spek({
             provider.cancelReload()
             file.toFile().writeText("foo=bar3")
             Thread.sleep(5000) // Another wait for that
-            provider.get<String>("foo").should.be.equal("bar2") // We hav ecanceled the reload so no more reloads
-            file.toFile().deleteOnExit()
+            provider.get<String>("foo").should.be.equal("bar2") // We have canceled the reload so no more reloads
+        }
+    }
+
+    describe("a provider with a filechange reloader (with subdirectory)") {
+        val file = Paths.get("subdir", "reloadedfile.properties")
+
+        file.parent.toFile().mkdir()
+        file.parent.toFile().deleteOnExit()
+        file.toFile().deleteOnExit()
+        file.toFile().writeText("foo=bar")
+
+        val unrelatedFile = Paths.get("subdir/subdir", "reloadedfile.properties")
+        unrelatedFile.parent.toFile().mkdir()
+        unrelatedFile.parent.toFile().deleteOnExit()
+        unrelatedFile.toFile().deleteOnExit()
+        unrelatedFile.toFile().writeText("foo=bar")
+        val provider = DefaultConfigProvider(
+                PropertyConfigLoader(FileConfigSource(file)),
+                FileChangeReloadStrategy(file),
+                ProxyBinder()
+        )
+
+        it("should have this config loaded") {
+            provider.get<String>("foo").should.be.equal("bar")
+        }
+
+        it("should update the configuration") {
+            Thread.sleep(5000) // We need to wait a little bit for the event watcher to be triggered
+            file.toFile().writeText("foo=bar2")
+            Thread.sleep(5000) // Another wait for that
+            provider.get<String>("foo").should.be.equal("bar2")
+            provider.cancelReload()
+            file.toFile().writeText("foo=bar3")
+            Thread.sleep(5000) // Another wait for that
+            provider.get<String>("foo").should.be.equal("bar2") // We have canceled the reload so no more reloads
         }
     }
 })


### PR DESCRIPTION
Updated the File Change Reloading Strategy to work with config files 
in subdirectories. It resolves the event's filename using the parent
and compares it to the provided file's absolute path. Added tests to
go along with the changes.