### PR TITLE
Make TimedReloadStrategy error-prone and reusable

### DIFF
--- a/cfg4k-core/src/main/kotlin/com/jdiazcano/cfg4k/reloadstrategies/TimedReloadStrategy.kt
+++ b/cfg4k-core/src/main/kotlin/com/jdiazcano/cfg4k/reloadstrategies/TimedReloadStrategy.kt
@@ -44,12 +44,7 @@ class TimedReloadStrategy(private val time: Long,
 
     override fun register(configProvider: ConfigProvider) {
         reloadTasks.computeIfAbsent(configProvider) { cp ->
-            val reload = {
-                try {
-                    cp.reload()
-                } catch (ignored: Exception) {
-                }
-            }
+            val reload = { cp.reload() }
             when (mode) {
                 FIXED_RATE -> executor.scheduleAtFixedRate(reload, 0, time, unit)
                 FIXED_DELAY -> executor.scheduleWithFixedDelay(reload, 0, time, unit)

--- a/cfg4k-core/src/test/kotlin/com/jdiazcano/cfg4k/TimedReloadStrategyTest.kt
+++ b/cfg4k-core/src/test/kotlin/com/jdiazcano/cfg4k/TimedReloadStrategyTest.kt
@@ -82,27 +82,11 @@ nested.a=reloaded nestedb
             checkProvider(overrideFile, provider, text, true)
         }
 
-        it("error on reload doesn't prevent further reload attempts") {
-            var reloadCounter = 0
-            val provider = reloadTestProvider {
-                // Every second reload throws an exception
-                if (reloadCounter++ % 2 == 0) throw Exception("simulate reload failure")
-            }
-            val reloadStrategy = TimedReloadStrategy(100, TimeUnit.MILLISECONDS)
-
-            reloadStrategy.register(provider)
-            Thread.sleep(1000)
-            reloadStrategy.deregister(provider)
-
-            // Expected value is low enough to avoid test flakiness
-            reloadCounter.should.be.least(5)
-        }
-
         it("reload strategy can be reused by multiple providers") {
             var reloadCounter1 = 0
-            val provider1 = reloadTestProvider { reloadCounter1 ++ }
+            val provider1 = reloadTestProvider { reloadCounter1++ }
             var reloadCounter2 = 0
-            val provider2 = reloadTestProvider { reloadCounter2 ++ }
+            val provider2 = reloadTestProvider { reloadCounter2++ }
             val reloadStrategy = TimedReloadStrategy(10, TimeUnit.MILLISECONDS)
 
             reloadStrategy.register(provider1)
@@ -113,7 +97,6 @@ nested.a=reloaded nestedb
             val lastSeenReloadCounter2 = reloadCounter2
             Thread.sleep(100)
             reloadStrategy.deregister(provider2)
-            val finishedReloadCounter2 = reloadCounter2
 
             // provider1 must've been unregistered just before lastSeenReloadCounter1 was observed,
             // and at most one running reload might've increased reloadCounter1 since then


### PR DESCRIPTION
Current `TimedReloadStrategy` has two flaws:
* the underlying `Timer` terminates if any reload attempt fails with an exception. This makes this reload strategy suck when dealing with I/O, for instance, reloading from a remote URL.
* if `register(ConfigProvider)` is called multiple times, only the last `ConfigProvider` can effectively call `deregister()`, while all previously registered timers will be lost. This makes the reload strategy not reusable, while its API suggests that it might be reused.

This change makes `TimedReloadStrategy` use a scheduled executor service with error-prone `reload()` call to prevent subsequent reload attempts from auto-cancelling, and use a map of `ConfigProvider`s to register and unregister them properly.