### PR TITLE
Authentication for URLConfigSource

### DIFF
--- a/cfg4k-core/build.gradle
+++ b/cfg4k-core/build.gradle
@@ -8,5 +8,6 @@ dependencies {
 
     testCompile libraries.junitrunner
     testCompile libraries.expekt
+    testCompile libraries.mockwebserver
     testRuntime libraries.jetbrains.spek.engine
 }

--- a/cfg4k-core/src/main/kotlin/com/jdiazcano/cfg4k/sources/URLConfigSource.kt
+++ b/cfg4k-core/src/main/kotlin/com/jdiazcano/cfg4k/sources/URLConfigSource.kt
@@ -1,10 +1,27 @@
 package com.jdiazcano.cfg4k.sources
 
 import java.io.InputStream
+import java.net.HttpURLConnection
 import java.net.URL
+import java.util.*
 
-class URLConfigSource(private val url: URL): ConfigSource {
+class URLConfigSource(private val url: URL,
+                      private val authHeader: String? = null) : ConfigSource {
     override fun read(): InputStream {
-        return url.openStream()
+        val connection = url.openConnection() as HttpURLConnection
+        if (authHeader != null) {
+            connection.setRequestProperty("Authorization", authHeader)
+        }
+
+        return connection.inputStream
     }
+}
+
+/**
+ * Generates `Authorization` header value for basic authentication with the given [username] and [password].
+ */
+fun basicAuth(username: String, password: String): String {
+    val credentials = "$username:$password"
+    val encodedCredentials = Base64.getEncoder().encodeToString(credentials.toByteArray(Charsets.UTF_8))
+    return "Basic $encodedCredentials"
 }

--- a/cfg4k-core/src/test/kotlin/com/jdiazcano/cfg4k/URLConfigSourceTest.kt
+++ b/cfg4k-core/src/test/kotlin/com/jdiazcano/cfg4k/URLConfigSourceTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-2016 Javier Díaz-Cano Martín-Albo (javierdiazcanom@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jdiazcano.cfg4k
+
+import com.jdiazcano.cfg4k.sources.URLConfigSource
+import com.jdiazcano.cfg4k.sources.basicAuth
+import com.winterbe.expekt.should
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import java.net.URL
+import java.util.concurrent.TimeUnit
+
+private const val AUTH_HEADER = "Authorization"
+
+class URLConfigSourceTest : Spek({
+    describe("config source fetching data from a URL") {
+        val configSource = "a: b"
+        val configPath = "/path"
+        lateinit var server: MockWebServer
+        lateinit var configUrl: URL
+
+        beforeEachTest {
+            server = MockWebServer()
+            server.start()
+            configUrl = server.url(configPath).url()
+            server.enqueue(MockResponse().setBody(configSource))
+        }
+        afterEachTest {
+            server.shutdown()
+        }
+
+        it("should fetch config") {
+            val source = URLConfigSource(configUrl)
+
+            source.read().bufferedReader().useLines {
+                val fetchedConfigSource = it.toList().single()
+                fetchedConfigSource.should.be.equal(configSource)
+
+                val request = server.takeRequest(1, TimeUnit.MILLISECONDS)
+                request.method.should.be.equal("GET")
+                request.path.should.be.equal(configPath)
+            }
+        }
+
+        it("should fetch config without authentication") {
+            val source = URLConfigSource(configUrl)
+            // Calling use to auto-close the stream
+            source.read().use {
+                val request = server.takeRequest(1, TimeUnit.MILLISECONDS)
+                request.getHeader(AUTH_HEADER).should.be.`null`
+            }
+        }
+
+        it("should fetch config with provided authentication header") {
+            val authHeader = "some-header"
+            val source = URLConfigSource(configUrl, authHeader)
+            // Calling use to auto-close the stream
+            source.read().use {
+                val request = server.takeRequest(1, TimeUnit.MILLISECONDS)
+                request.getHeader(AUTH_HEADER).should.be.equal(authHeader)
+            }
+        }
+
+    }
+
+    describe("authentication header generators") {
+        it("basic authentication generator") {
+            basicAuth("", "").should.be.equal("Basic Og==")
+            basicAuth("foo", "bar").should.be.equal("Basic Zm9vOmJhcg==")
+            basicAuth("username", "password").should.be.equal("Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
+        }
+    }
+})

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -11,7 +11,8 @@ ext.versions = [
         expekt: '0.5.0',
         junitrunner: '1.1.0-M1',
         snakeyaml: '1.19',
-        jcommander: '1.72'
+        jcommander: '1.72',
+        mockwebserver: '3.9.1'
 ]
 
 ext.libraries = [
@@ -35,5 +36,6 @@ ext.libraries = [
         typesafe: "com.typesafe:config:$versions.typesafe",
         snakeyaml: "org.yaml:snakeyaml:$versions.snakeyaml",
         klaxon: "com.beust:klaxon:$versions.klaxon",
-        jcommander: "com.beust:jcommander:$versions.jcommander"
+        jcommander: "com.beust:jcommander:$versions.jcommander",
+        mockwebserver: "com.squareup.okhttp3:mockwebserver:$versions.mockwebserver"
 ]


### PR DESCRIPTION
Current `URLConfigSource` lacks authentication, so the URL can only be public to be consumed by cfg4k (unless you tweak the global `java.net.Authenticator` which seems not the best way).

This change makes `URLConfigSource` to accept an optional generic content for `Authorization` header to be used when fetching the config from the provided URL.
A helper function for encoding basic auth credentials is provided along the way just because it's easy on one hand but not completely trivial on the other.