### PR TITLE
Move Spek API to test dependencies

### DIFF
--- a/cfg4k-bytebuddy/build.gradle
+++ b/cfg4k-bytebuddy/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile libraries.jetbrains.kotlin.stdlib
     compile libraries.bytebuddy
 
+    testCompile libraries.jetbrains.spek.api
     testCompile libraries.junitrunner
     testCompile libraries.expekt
     testRuntime libraries.jetbrains.spek.engine

--- a/cfg4k-cli/build.gradle
+++ b/cfg4k-cli/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile libraries.jetbrains.kotlin.stdlib
     compile libraries.jcommander
 
+    testCompile libraries.jetbrains.spek.api
     testCompile libraries.junitrunner
     testCompile libraries.expekt
     testRuntime libraries.jetbrains.spek.engine

--- a/cfg4k-core/build.gradle
+++ b/cfg4k-core/build.gradle
@@ -2,10 +2,10 @@ apply from: '../gradle/versions.gradle'
 
 dependencies {
     compile libraries.jetbrains.kotlin.stdlib
-    compile libraries.jetbrains.spek.api
     compile libraries.jetbrains.kotlin.test
     compile libraries.jetbrains.kotlin.reflect
 
+    testCompile libraries.jetbrains.spek.api
     testCompile libraries.junitrunner
     testCompile libraries.expekt
     testRuntime libraries.jetbrains.spek.engine

--- a/cfg4k-git/build.gradle
+++ b/cfg4k-git/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile libraries.jetbrains.kotlin.stdlib
     compile libraries.eclipse.jgit
 
+    testCompile libraries.jetbrains.spek.api
     testCompile libraries.junitrunner
     testCompile libraries.expekt
     testRuntime libraries.jetbrains.spek.engine

--- a/cfg4k-hocon/build.gradle
+++ b/cfg4k-hocon/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile libraries.jetbrains.kotlin.stdlib
     compile libraries.typesafe
 
+    testCompile libraries.jetbrains.spek.api
     testCompile libraries.junitrunner
     testCompile libraries.expekt
     testRuntime libraries.jetbrains.spek.engine

--- a/cfg4k-json/build.gradle
+++ b/cfg4k-json/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile libraries.jetbrains.kotlin.stdlib
     compile libraries.klaxon
 
+    testCompile libraries.jetbrains.spek.api
     testCompile libraries.junitrunner
     testCompile libraries.expekt
     testRuntime libraries.jetbrains.spek.engine

--- a/cfg4k-yaml/build.gradle
+++ b/cfg4k-yaml/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile libraries.jetbrains.kotlin.stdlib
     compile libraries.snakeyaml
 
+    testCompile libraries.jetbrains.spek.api
     testCompile libraries.junitrunner
     testCompile libraries.expekt
     testRuntime libraries.jetbrains.spek.engine

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     compile project(":cfg4k-core")
     compile project(":cfg4k-json")
     compile project(":cfg4k-bytebuddy")
+    compile libraries.jetbrains.spek.api
 
     compile libraries.junitrunner
     compile libraries.expekt


### PR DESCRIPTION
I noticed that `org.jetbrains.spek:spek-api` is in compile dependencies of `cfg4k-core` while it should (and is) only used in tests.

This change moves it to test-compile dependencies.