### PR TITLE
cfg4k-core: handle config file symlink changes

### DIFF
--- a/cfg4k-core/src/test/kotlin/com/jdiazcano/cfg4k/reloadstrategies/FileChangeReloadStrategyTest.kt
+++ b/cfg4k-core/src/test/kotlin/com/jdiazcano/cfg4k/reloadstrategies/FileChangeReloadStrategyTest.kt
@@ -7,9 +7,7 @@ import com.jdiazcano.cfg4k.providers.get
 import com.jdiazcano.cfg4k.sources.FileConfigSource
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.FeatureSpec
-import java.io.File
 import java.nio.file.Files
-import java.nio.file.Paths
 
 class FileChangeReloadStrategyTest : FeatureSpec({
     feature("a provider with a filechange reloader") {
@@ -63,6 +61,57 @@ class FileChangeReloadStrategyTest : FeatureSpec({
             provider.cancelReload()
             file.writeText("foo=bar3")
             Thread.sleep(5000) // Another wait for that
+            provider.get<String>("foo").shouldBe("bar2") // We have canceled the reload so no more reloads
+        }
+    }
+
+    feature("a provider with a filechange reloader (with a symlink chain)") {
+        // simulate a Kubernetes ConfigMap setup
+        val tempDir = Files.createTempDirectory("cfg4k")
+        tempDir.toFile().let {
+            it.mkdirs()
+            it.deleteOnExit()
+        }
+
+        val numbered1 = Files.createDirectory(tempDir.resolve("..10001"))
+        val numbered2 = Files.createDirectory(tempDir.resolve("..10002"))
+        val dataLn = Files.createSymbolicLink(tempDir.resolve("..data"), tempDir.relativize(numbered1))
+
+        val file1 = numbered1.resolve("reloadedfile.properties").toFile()
+        file1.writeText("foo=bar")
+
+        val file2 = numbered2.resolve("reloadedfile.properties").toFile()
+        file2.writeText("foo=bar2")
+
+        val configFileLn = Files.createSymbolicLink(tempDir.resolve("reloadedfile.properties"),
+                tempDir.relativize(dataLn).resolve("reloadedfile.properties"))
+
+        val provider = DefaultConfigProvider(
+                PropertyConfigLoader(FileConfigSource(configFileLn)),
+                FileChangeReloadStrategy(configFileLn)
+        )
+
+        scenario("should have this config loaded") {
+            provider.get<String>("foo").shouldBe("bar")
+        }
+
+        scenario("should update the configuration when a soft link is updated") {
+            // change the ..data link like Kubernetes does
+            Files.delete(dataLn)
+            Files.createSymbolicLink(tempDir.resolve("..data"), tempDir.relativize(numbered2))
+
+            Thread.sleep(5000) // We need to wait a little bit for the event watcher to be triggered
+
+            provider.get<String>("foo").shouldBe("bar2")
+
+            provider.cancelReload()
+
+            // change the ..data link like Kubernetes does
+            Files.delete(dataLn)
+            Files.createSymbolicLink(tempDir.resolve("..data"), tempDir.relativize(numbered1))
+
+            Thread.sleep(5000) // We need to wait a little bit for the event watcher to be triggered
+
             provider.get<String>("foo").shouldBe("bar2") // We have canceled the reload so no more reloads
         }
     }


### PR DESCRIPTION
Fixes issue #65 

The changes *should* be backward compatible -- at least all the existing tests for this class pass. I've added a new test for this case as well.